### PR TITLE
Added the ability to retrieve any list of properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 \.idea/
+
+# Visual Studio Code Debugger settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -19,36 +19,45 @@ import italian_dictionary
 # Use this to get only the meaning 
 definition = italian_dictionary.get_definition('cane', limit=3, all_data=False) 
 
-#Use this to get all datas of a word (all_data default is True)
-datas = italian_dictionary.get_definition('albero')
+# Use this to get all data for a word (all_data default is True)
+data = italian_dictionary.get_definition('albero')
+
+# Use this to get a subset of the properties, for example 'grammatica' and 'pronuncia'
+data = italian_dictionary('albero', all_data=False, properties=['grammatica', 'pronuncia'])
+
+# Use this to get single property other than the meaning, for example 'lemma'
+# Will return the value of the property, not a dictionary containing the one value.
+data = italian_dictionary('albero', all_data=False, properties=['lemma'])
+
 ```
- #### Complete data response
+ ### Complete data response
  This function will return a dictionary like this:
  ```python
 {
-'sillabe': ['al', 'be', 'ro'],
-'lemma': 'àlbero', 
-'pronuncia': ' /ˈalbero/', 
-'grammatica': ['sostantivo maschile'], 
-'definizione': ['pianta con fusto alto, legnoso, provvisto di rami nella parte superiore', 
-                "MARINERIA --  palo che regge i pennoni con le vele e tutta l'attrezzatura", 
-                'MECCANICA --  parte rotante, generalmente cilindrica, che, in una macchina, ha la funzione di trasmettere potenza meccanica da un organo a un altro'], 
-'locuzioni': ["linea d'asse o d'alberi di una nave", 
-              'ad albero che cade dàgli dàgli', 
-              'svasare un albero', 
-              'albero portaelica', 
-              'albero a calcese', 
-              'albero castalio', 
-              'albero matricino', 
-              'alberi a mezzovento', 
-              'albero optronico', 
-              'albero pizzuto', 
-              'andare agli alberi pizzuti', 
-              'alberi rinterzati', 
-              'albero del sego'] 
+    'sillabe': ['al', 'be', 'ro'],
+    'lemma': 'àlbero', 
+    'pronuncia': ' /ˈalbero/', 
+    'grammatica': ['sostantivo maschile'], 
+    'definizione': ['pianta con fusto alto, legnoso, provvisto di rami nella parte superiore', 
+                    "MARINERIA --  palo che regge i pennoni con le vele e tutta l'attrezzatura", 
+                    'MECCANICA --  parte rotante, generalmente cilindrica, che, in una macchina, ha la funzione di trasmettere potenza meccanica da un organo a un altro'], 
+    'locuzioni': ["linea d'asse o d'alberi di una nave", 
+                'ad albero che cade dàgli dàgli', 
+                'svasare un albero', 
+                'albero portaelica', 
+                'albero a calcese', 
+                'albero castalio', 
+                'albero matricino', 
+                'alberi a mezzovento', 
+                'albero optronico', 
+                'albero pizzuto', 
+                'andare agli alberi pizzuti', 
+                'alberi rinterzati', 
+                'albero del sego'] 
 }
 ```
 ## Tests
-To run tests you need ```pytest```
+To run tests you need ```pytest```.
+
 When in project folder:
 ```python -m pytest```

--- a/italian_dictionary/dictionary.py
+++ b/italian_dictionary/dictionary.py
@@ -2,11 +2,19 @@ from italian_dictionary import scraper
 
 
 # ------italian_dictionary-------
-def get_definition(word, all_data=True, limit=None):
+def get_definition(word, all_data=True, limit=None, properties=['definizione']):
     if all_data:
-        return scraper.get_data(word)
+        return scraper.get_data(word, ['definizione', 'sillabe', 'lemma', 'pronuncia', 'grammatica', 'locuzioni'])
+            # data = {'definizione': get_defs(soup), 'sillabe': get_sillabe(soup, word), 'lemma': get_lemma(soup),
+    #         'pronuncia': get_pronuncia(soup), 'grammatica': get_grammatica(soup), 'locuzioni': get_locuzioni(soup),
+    #         'url': url}
     else:
-        defs = scraper.get_data(word, all_data=False)
-        if limit is not None and len(defs) > limit:
-            del defs[limit:]
-        return defs
+        data = scraper.get_data(word, all_data=False, properties=properties)
+        if ('definizione' in properties):
+            if limit is not None and len(data['definizione']) > limit:
+                del data['definizione'][limit:]
+        # If just one property is requested, return the property value, not the dictionary
+        if len(properties) == 1:
+            return data[properties[0]]
+        else:
+            return data

--- a/italian_dictionary/exceptions.py
+++ b/italian_dictionary/exceptions.py
@@ -1,3 +1,5 @@
 class WordNotFoundError(Exception):
     pass
 
+class InvalidPropertyError(Exception):
+    pass

--- a/italian_dictionary/scraper.py
+++ b/italian_dictionary/scraper.py
@@ -22,7 +22,7 @@ def get_soup(url):
 def get_lemma(soup):
     lemma = soup.find('span', class_='lemma')
     if lemma is not None:
-        return lemma.find(text=True, recursive=False).rstrip() # Getting only span text + removing white spaces at the end
+        return lemma.find(string=True, recursive=False).rstrip() # Getting only span text + removing white spaces at the end
 
 
 def get_sillabe(soup, word):
@@ -31,7 +31,7 @@ def get_sillabe(soup, word):
     for el in small_list:
         if el.parent not in lemma.children:
             try:
-                sillabe = el.span.find(text=True, recursive=False)
+                sillabe = el.span.find(string=True, recursive=False)
             except AttributeError:  # Word has no syllable division
                 return [word]
             break
@@ -86,13 +86,34 @@ def get_defs(soup):
     return defs
 
 
-def get_data(word, all_data=True):
+def get_data(word, properties, all_data=True):
     url = build_url(URL.format(word))
     soup = get_soup(url)
-    if all_data is False:
-        return get_defs(soup)
+    data = {}
 
-    data = {'definizione': get_defs(soup), 'sillabe': get_sillabe(soup, word), 'lemma': get_lemma(soup),
-            'pronuncia': get_pronuncia(soup), 'grammatica': get_grammatica(soup), 'locuzioni': get_locuzioni(soup),
-            'url': url}
+    if len(properties) == 0:
+        # Should never happen if this function is only called from get_definition() in dictionary.py
+        raise LookupError("No properties specified.")
+    for property in properties:
+        if property == "definizione":
+            data["definizione"] = get_defs(soup)
+        elif property == "lemma":
+            data["lemma"] = get_lemma(soup)
+        elif property == "sillabe":
+            data["sillabe"] = get_sillabe(soup, word)
+        elif property == "pronuncia":
+            data["pronuncia"] = get_pronuncia(soup)
+        elif property == "grammatica":
+            data["grammatica"] = get_grammatica(soup)
+        elif property == "locuzioni":
+            data["locuzioni"] = get_locuzioni(soup)
+        elif (property in data) is False:
+            raise exceptions.InvalidPropertyError("Property {} not found in data returned from {}")
+    
+    # if all_data is False:
+    #     return get_defs(soup)
+
+    # data = {'definizione': get_defs(soup), 'sillabe': get_sillabe(soup, word), 'lemma': get_lemma(soup),
+    #         'pronuncia': get_pronuncia(soup), 'grammatica': get_grammatica(soup), 'locuzioni': get_locuzioni(soup),
+    #         'url': url}
     return data

--- a/italian_dictionary/scraper.py
+++ b/italian_dictionary/scraper.py
@@ -109,11 +109,5 @@ def get_data(word, properties, all_data=True):
             data["locuzioni"] = get_locuzioni(soup)
         elif (property in data) is False:
             raise exceptions.InvalidPropertyError("Property {} not found in data returned from {}")
-    
-    # if all_data is False:
-    #     return get_defs(soup)
-
-    # data = {'definizione': get_defs(soup), 'sillabe': get_sillabe(soup, word), 'lemma': get_lemma(soup),
-    #         'pronuncia': get_pronuncia(soup), 'grammatica': get_grammatica(soup), 'locuzioni': get_locuzioni(soup),
-    #         'url': url}
+            
     return data

--- a/italian_dictionary/scraper.py
+++ b/italian_dictionary/scraper.py
@@ -108,6 +108,6 @@ def get_data(word, properties, all_data=True):
         elif property == "locuzioni":
             data["locuzioni"] = get_locuzioni(soup)
         elif (property in data) is False:
-            raise exceptions.InvalidPropertyError("Property {} not found in data returned from {}")
+            raise exceptions.InvalidPropertyError("Property {} not found in data returned from {}".format(property, url))
             
     return data

--- a/tests/italian_dictionary_test.py
+++ b/tests/italian_dictionary_test.py
@@ -35,6 +35,18 @@ class Test_ItalianDictionary():
         data = get_definition(word)
         assert type(data) is dict
         assert len(data) > 0
+    def test_oneProperty(self):
+        word = 'albero'
+        data = get_definition(word, all_data=False, properties=['pronuncia'])
+        assert type(data) is str
+        assert data != ''
+    def test_multipleProperties(self):
+        word = 'albero'
+        data = get_definition(word, all_data=False, properties=['grammatica', 'pronuncia'])
+        assert type(data) is dict
+        assert len(data) > 0
+        assert data['pronuncia'] != ''
+        assert type(data['grammatica']) is list
 
 class TestErrors:
     def test_errors(self):
@@ -42,3 +54,5 @@ class TestErrors:
             get_definition('nfdifneif')
         with pytest.raises(exceptions.WordNotFoundError):
             get_definition('afefemmm')
+        with pytest.raises(exceptions.InvalidPropertyError):
+            get_definition('albero', all_data=False, properties=['adsfads', 'nnszdd'])


### PR DESCRIPTION
When using this module, I found that unless I wanted just the definition, I had to retrieve all the data for a word.

This PR allows any set of properties to be retrieved, for example just the `lemma` property or any subset of properties.

I added a `properties` parameter and changed the semantics of `all_data` slightly - `all_data` must be `False` for the `properties` parameter to work.

It's backwards compatible: the behavior for just returning the definition is now a default value for `properties`.

Updated unit tests and documentation. Also changed the `.find` methods that used `text=True` to `string=True` to fix a method deprecation warning.